### PR TITLE
Fix compilation crash and warnings

### DIFF
--- a/haskell-ffi/Sources/HaskellFFI/HaskellFFI.swift
+++ b/haskell-ffi/Sources/HaskellFFI/HaskellFFI.swift
@@ -33,6 +33,10 @@ public struct HsCallJSON {
     }
 }
 
+public enum HsFFIError: Error {
+    case requiredSizeIs(Int)
+}
+
 public func hstub() -> Never {
     fatalError("Somehow, a stub for a foreign-imported Haskell function was called")
 }


### PR DESCRIPTION
Fixes #7 

- Moved HsFFIError definition to HaskellFFI.hs
- Made hs_dec definition conditional to avoid unused variable warning
- Added conditional try for function generator to avoid unnecessary try warning

Lmk if you want these broken up.